### PR TITLE
Update jboss-web.xml to prevent eclipse show error

### DIFF
--- a/src/main/webapp/WEB-INF/jboss-web.xml
+++ b/src/main/webapp/WEB-INF/jboss-web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jboss-web xmlns="http://www.jboss.com/xml/ns/javaee"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="       http://www.jboss.com/xml/ns/javaee       http://www.jboss.org/j2ee/schema/jboss-web_5_1.xsd">
+	xsi:schemaLocation="http://www.jboss.com/xml/ns/javaee">
 	<context-root>/admin-starter</context-root>
 	<security-domain>jaspitest</security-domain>
 </jboss-web>


### PR DESCRIPTION
Eclipse show following error without correction:

cvc-complex-type.2.4.a: Invalid content was found starting with element 'security-domain'. One of '{"http://www.jboss.com/xml/ns/javaee":virtual-host, "http://www.jboss.com/xml/ns/javaee":use-session-cookies, "http://www.jboss.com/xml/ns/javaee":replication-config, "http://
 www.jboss.com/xml/ns/javaee":env-entry, "http://www.jboss.com/xml/ns/javaee":ejb-ref, "http://www.jboss.com/xml/ns/javaee":ejb-local-ref, "http://www.jboss.com/xml/ns/javaee":service-ref, "http://www.jboss.com/xml/ns/javaee":resource-ref, "http://www.jboss.com/xml/ns/
 javaee":resource-env-ref, "http://www.jboss.com/xml/ns/javaee":message-destination-ref, "http://www.jboss.com/xml/ns/javaee":persistence-context-ref, "http://www.jboss.com/xml/ns/javaee":persistence-unit-ref, "http://www.jboss.com/xml/ns/javaee":post-construct, "http://
 www.jboss.com/xml/ns/javaee":pre-destroy, "http://www.jboss.com/xml/ns/javaee":security-role, "http://www.jboss.com/xml/ns/javaee":message-destination, "http://www.jboss.com/xml/ns/javaee":webservice-description, "http://www.jboss.com/xml/ns/javaee":depends, "http://
 www.jboss.com/xml/ns/javaee":servlet, "http://www.jboss.com/xml/ns/javaee":max-active-sessions, "http://www.jboss.com/xml/ns/javaee":passivation-config}' is expected.